### PR TITLE
Add models and DbContext for appointments system

### DIFF
--- a/Saxess/Models/Appointment.cs
+++ b/Saxess/Models/Appointment.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Saxess.Models;
+
+public partial class Appointment
+{
+    public int AppointmentId { get; set; }
+
+    public DateTime? AppointmentDatetime { get; set; }
+
+    public int? EmployeeId { get; set; }
+
+    public int? CustomerId { get; set; }
+
+    public int? TreatmentId { get; set; }
+
+    public virtual Customer? Customer { get; set; }
+
+    public virtual Employee? Employee { get; set; }
+
+    public virtual Treatment? Treatment { get; set; }
+}

--- a/Saxess/Models/Customer.cs
+++ b/Saxess/Models/Customer.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Saxess.Models;
+
+public partial class Customer
+{
+    public int CustomerId { get; set; }
+
+    public string? FirstName { get; set; }
+
+    public string? LastName { get; set; }
+
+    public string? Email { get; set; }
+
+    public virtual ICollection<Appointment> Appointments { get; set; } = new List<Appointment>();
+}

--- a/Saxess/Models/Employee.cs
+++ b/Saxess/Models/Employee.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Saxess.Models;
+
+public partial class Employee
+{
+    public int EmployeeId { get; set; }
+
+    public string? FirstName { get; set; }
+
+    public string? LastName { get; set; }
+
+    public int? Age { get; set; }
+
+    public virtual ICollection<Appointment> Appointments { get; set; } = new List<Appointment>();
+
+    public virtual ICollection<Treatment> Treatments { get; set; } = new List<Treatment>();
+}

--- a/Saxess/Models/SassexDbContext.cs
+++ b/Saxess/Models/SassexDbContext.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore;
+
+namespace Saxess.Models;
+
+public partial class SassexDbContext : DbContext
+{
+    public SassexDbContext()
+    {
+    }
+
+    public SassexDbContext(DbContextOptions<SassexDbContext> options)
+        : base(options)
+    {
+    }
+
+    public virtual DbSet<Appointment> Appointments { get; set; }
+
+    public virtual DbSet<Customer> Customers { get; set; }
+
+    public virtual DbSet<Employee> Employees { get; set; }
+
+    public virtual DbSet<Treatment> Treatments { get; set; }
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+#warning To protect potentially sensitive information in your connection string, you should move it out of source code. You can avoid scaffolding the connection string by using the Name= syntax to read it from configuration - see https://go.microsoft.com/fwlink/?linkid=2131148. For more guidance on storing connection strings, see https://go.microsoft.com/fwlink/?LinkId=723263.
+        => optionsBuilder.UseSqlServer("Data Source=PC30447\\SQLEXPRESS;Database=SassexDB;Integrated Security=True;Trust Server Certificate=true;");
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<Appointment>(entity =>
+        {
+            entity.HasKey(e => e.AppointmentId).HasName("PK__Appointm__8ECDFCA206FA32F4");
+
+            entity.Property(e => e.AppointmentId).HasColumnName("AppointmentID");
+            entity.Property(e => e.AppointmentDatetime).HasColumnType("datetime");
+            entity.Property(e => e.CustomerId).HasColumnName("CustomerID");
+            entity.Property(e => e.EmployeeId).HasColumnName("EmployeeID");
+            entity.Property(e => e.TreatmentId).HasColumnName("TreatmentID");
+
+            entity.HasOne(d => d.Customer).WithMany(p => p.Appointments)
+                .HasForeignKey(d => d.CustomerId)
+                .HasConstraintName("FK__Appointme__Custo__5070F446");
+
+            entity.HasOne(d => d.Employee).WithMany(p => p.Appointments)
+                .HasForeignKey(d => d.EmployeeId)
+                .HasConstraintName("FK__Appointme__Emplo__4F7CD00D");
+
+            entity.HasOne(d => d.Treatment).WithMany(p => p.Appointments)
+                .HasForeignKey(d => d.TreatmentId)
+                .HasConstraintName("FK__Appointme__Treat__5165187F");
+        });
+
+        modelBuilder.Entity<Customer>(entity =>
+        {
+            entity.HasKey(e => e.CustomerId).HasName("PK__Customer__A4AE64B8EC55B8F1");
+
+            entity.Property(e => e.CustomerId).HasColumnName("CustomerID");
+            entity.Property(e => e.Email)
+                .HasMaxLength(100)
+                .IsUnicode(false);
+            entity.Property(e => e.FirstName)
+                .HasMaxLength(50)
+                .IsUnicode(false);
+            entity.Property(e => e.LastName)
+                .HasMaxLength(50)
+                .IsUnicode(false);
+        });
+
+        modelBuilder.Entity<Employee>(entity =>
+        {
+            entity.HasKey(e => e.EmployeeId).HasName("PK__Employee__7AD04FF1B387E98D");
+
+            entity.Property(e => e.EmployeeId).HasColumnName("EmployeeID");
+            entity.Property(e => e.FirstName)
+                .HasMaxLength(50)
+                .IsUnicode(false);
+            entity.Property(e => e.LastName)
+                .HasMaxLength(50)
+                .IsUnicode(false);
+
+            entity.HasMany(d => d.Treatments).WithMany(p => p.Employees)
+                .UsingEntity<Dictionary<string, object>>(
+                    "EmployeesTreatment",
+                    r => r.HasOne<Treatment>().WithMany()
+                        .HasForeignKey("TreatmentId")
+                        .OnDelete(DeleteBehavior.ClientSetNull)
+                        .HasConstraintName("FK__Employees__Treat__5535A963"),
+                    l => l.HasOne<Employee>().WithMany()
+                        .HasForeignKey("EmployeeId")
+                        .OnDelete(DeleteBehavior.ClientSetNull)
+                        .HasConstraintName("FK__Employees__Treat__5441852A"),
+                    j =>
+                    {
+                        j.HasKey("EmployeeId", "TreatmentId").HasName("PK__Employee__7B753480ED96E5E5");
+                        j.ToTable("EmployeesTreatments");
+                        j.IndexerProperty<int>("EmployeeId").HasColumnName("EmployeeID");
+                        j.IndexerProperty<int>("TreatmentId").HasColumnName("TreatmentID");
+                    });
+        });
+
+        modelBuilder.Entity<Treatment>(entity =>
+        {
+            entity.HasKey(e => e.TreatmentId).HasName("PK__Treatmen__1A57B71188B55E49");
+
+            entity.Property(e => e.TreatmentId).HasColumnName("TreatmentID");
+            entity.Property(e => e.TreatmentName)
+                .HasMaxLength(50)
+                .IsUnicode(false);
+            entity.Property(e => e.TreatmentType)
+                .HasMaxLength(50)
+                .IsUnicode(false);
+        });
+
+        OnModelCreatingPartial(modelBuilder);
+    }
+
+    partial void OnModelCreatingPartial(ModelBuilder modelBuilder);
+}

--- a/Saxess/Models/Treatment.cs
+++ b/Saxess/Models/Treatment.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Saxess.Models;
+
+public partial class Treatment
+{
+    public int TreatmentId { get; set; }
+
+    public string? TreatmentName { get; set; }
+
+    public string? TreatmentType { get; set; }
+
+    public virtual ICollection<Appointment> Appointments { get; set; } = new List<Appointment>();
+
+    public virtual ICollection<Employee> Employees { get; set; } = new List<Employee>();
+}

--- a/Saxess/Saxess.csproj
+++ b/Saxess/Saxess.csproj
@@ -7,4 +7,12 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Updated Saxess.csproj to target .NET 8.0 and added package references for `Microsoft.EntityFrameworkCore.SqlServer` and `Microsoft.EntityFrameworkCore.Tools` (v9.0.1).

Added new models under the `Saxess.Models` namespace:
- `Appointment` with properties for appointment details and navigation properties for `Customer`, `Employee`, and `Treatment`.
- `Customer` with properties for customer details and a collection of `Appointments`.
- `Employee` with properties for employee details and collections of `Appointments` and `Treatments`.
- `Treatment` with properties for treatment details and collections of `Appointments` and `Employees`.

Added `SassexDbContext` inheriting from `DbContext` with `DbSet` properties for `Appointment`, `Customer`, `Employee`, and `Treatment`. Configured SQL Server connection string and entity configurations in `OnModelCreating`.